### PR TITLE
fix(build): gradlew failed on gradle 7.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ task pz(type: Zip, dependsOn: [':jar']) {
     into("jieba") {
         from configurations.distJars
         from 'build/libs'
+        from 'jieba-analysis/build/libs'
         from 'build/resources/main/plugin.xml'
         from 'build/resources/main/plugin-descriptor.properties'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ targetCompatibility = "1.8"
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 repositories {
-    maven { url "http://maven.aliyun.com/nexus/content/groups/public/" }
+    maven { url "https://maven.aliyun.com/nexus/content/groups/public/" }
     jcenter()
 }
 sourceSets {
@@ -43,7 +43,7 @@ task initSourceFolders {
 configurations {
     wagon
     distJars {
-        extendsFrom runtime
+        extendsFrom runtimeOnly
         exclude group: 'org.elasticsearch'
         exclude group: 'lucene-core'
         exclude group: 'org.apache.logging.log4j'
@@ -53,11 +53,15 @@ configurations {
 }
 
 dependencies {
-    compile project(":jieba-analysis")
-    compile 'org.elasticsearch:elasticsearch:7.7.0' // 适配不通版本的ES，可以修改这里。
-    compile 'org.apache.logging.log4j:log4j-api:2.7'
-    compile 'org.apache.logging.log4j:log4j-core:2.7'
-    testCompile 'junit:junit:4.12'
+    implementation project(":jieba-analysis")
+    implementation 'org.elasticsearch:elasticsearch:7.7.0' // 适配不通版本的ES，可以修改这里。
+    implementation 'org.apache.logging.log4j:log4j-api:2.7'
+    implementation 'org.apache.logging.log4j:log4j-core:2.7'
+    testImplementation 'junit:junit:4.12'
+}
+
+tasks.named("processResources") {
+    duplicatesStrategy = 'include'
 }
 
 task pz(type: Zip, dependsOn: [':jar']) {

--- a/custom_plugin_version.md
+++ b/custom_plugin_version.md
@@ -7,6 +7,8 @@
     - 主要修改 `version` 和 `elasticsearch.version` 分别表示插件的版本和支持ES的版本，同样，如果是支持6.3.0的插件，都改为6.3.0就可以。
 - 执行打包命令
 ```shell script
-./gradlews pz
+git submodule update --init --recursive
+gradle wrapper
+./gradlew pz
 ```
 - 打包好的插件在目录： `./build/distributions`


### PR DESCRIPTION
Signed-off-by: Thearas <thearas850@gmail.com>

I follow the document but meet some errors on `./gradlew pz`, same as #75. The gradle v5.x is too old, I don't think there're many people using it, so I make `./gradlew pz` available on gradle 7.x.

PTAL @sing1ee 
